### PR TITLE
Compiler Explorer link cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/take_before/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/take_before/actions/workflows/pre-commit-check.yml/badge.svg) [![Coverage](https://coveralls.io/repos/github/bemanproject/take_before/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/take_before?branch=main) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/take_before/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/take_before/actions/workflows/pre-commit-check.yml/badge.svg) [![Coverage](https://coveralls.io/repos/github/bemanproject/take_before/badge.svg?branch=main)](https://coveralls.io/github/bemanproject/take_before?branch=main) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg) [![Compiler Explorer Example](https://img.shields.io/badge/Try%20it%20on%20Compiler%20Explorer-grey?logo=compilerexplorer&logoColor=67c52a)](https://godbolt.org/z/5675xqrf6)
 
 `beman.take_before` is a C++ library implementing the `views::take_before` range adaptor as proposed in
 [P3220R2](https://wg21.link/P3220R2), conforming to
@@ -31,7 +31,7 @@ Full runable examples can be found in `examples/` - please check [./examples/REA
 
 ### Basic Usage: Pipe Syntax
 
--  [![Basic Usage@Compiler Explorer](https://img.shields.io/badge/Try%20it%20on%20Compiler%20Explorer-grey?logo=compilerexplorer&logoColor=67c52a)](https://godbolt.org/z/hf671dfof)
+-  [![Basic Usage@Compiler Explorer](https://img.shields.io/badge/Try%20it%20on%20Compiler%20Explorer-grey?logo=compilerexplorer&logoColor=67c52a)](https://godbolt.org/z/5675xqrf6)
 
 
 ```cpp
@@ -53,7 +53,7 @@ int main() {
 
 ### NTBS (Null-Terminated Byte String) - Primary Use Case
 
--  [![NTBS @Compiler Explorer](https://img.shields.io/badge/Try%20it%20on%20Compiler%20Explorer-grey?logo=compilerexplorer&logoColor=67c52a)](https://godbolt.org/z/9ad7qE7v9)
+-  [![NTBS @Compiler Explorer](https://img.shields.io/badge/Try%20it%20on%20Compiler%20Explorer-grey?logo=compilerexplorer&logoColor=67c52a)](https://godbolt.org/z/n8zbdeerT)
 
 ```cpp
 #include <beman/take_before/take_before.hpp>
@@ -72,7 +72,7 @@ int main() {
 
 ### Composition with Other Views
 
--  [![Composition @Compiler Explorer](https://img.shields.io/badge/Try%20it%20on%20Compiler%20Explorer-grey?logo=compilerexplorer&logoColor=67c52a)](https://godbolt.org/z/GdEsxzKdf)
+-  [![Composition @Compiler Explorer](https://img.shields.io/badge/Try%20it%20on%20Compiler%20Explorer-grey?logo=compilerexplorer&logoColor=67c52a)](https://godbolt.org/z/3bE6brW17)
 
 ```cpp
 #include <beman/take_before/take_before.hpp>


### PR DESCRIPTION
The updated compiler explorer links use compiler explorer's native library inclusion mechanism rather than raw.githubusercontent.com includes.

This commit also adds a Compiler Explorer badge to the README.md.

<!--
Please take note of the following when contributing:
- Our code of conduct: https://github.com/bemanproject/beman/blob/main/docs/code_of_conduct.md
- The Beman Standard: https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md
-->
